### PR TITLE
Add in-memory and DynamoDB storage backends

### DIFF
--- a/pkg/store/component.go
+++ b/pkg/store/component.go
@@ -1,0 +1,63 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/asecurityteam/nmap-scanner/pkg/domain"
+)
+
+const (
+	// TypeMemory indicates the in-memory selection.
+	TypeMemory = "MEMORY"
+	// TypeDynamo indicates the AWS DynamoDB selection.
+	TypeDynamo = "DYNAMODB"
+)
+
+// Config is the top level aggregate of all store implemenations.
+type Config struct {
+	Type   string `description:"The type of data store to use for results tracking."`
+	Memory *MemoryConfig
+	Dynamo *DynamoConfig
+}
+
+// Name of the configuration root.
+func (*Config) Name() string {
+	return "store"
+}
+
+// Component is the top level aggregate of all store components.
+type Component struct {
+	Memory *MemoryComponent
+	Dynamo *DynamoComponent
+}
+
+// NewComponent constructs a default component.
+func NewComponent() *Component {
+	return &Component{
+		Memory: NewMemoryComponent(),
+		Dynamo: NewDynamoComponent(),
+	}
+}
+
+// Settings returns the default configuration.
+func (c *Component) Settings() *Config {
+	return &Config{
+		Type:   TypeMemory,
+		Memory: c.Memory.Settings(),
+		Dynamo: c.Dynamo.Settings(),
+	}
+}
+
+// New generates a store from the configuration.
+func (c *Component) New(ctx context.Context, conf *Config) (domain.Store, error) {
+	switch {
+	case strings.EqualFold(conf.Type, TypeMemory):
+		return c.Memory.New(ctx, conf.Memory)
+	case strings.EqualFold(conf.Type, TypeDynamo):
+		return c.Dynamo.New(ctx, conf.Dynamo)
+	default:
+		return nil, fmt.Errorf("unknown store type %s", conf.Type)
+	}
+}

--- a/pkg/store/component_test.go
+++ b/pkg/store/component_test.go
@@ -1,0 +1,28 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStoreComponent(t *testing.T) {
+	cmp := NewComponent()
+	conf := cmp.Settings()
+	require.Equal(t, "store", conf.Name())
+
+	conf.Type = TypeMemory
+	s, err := cmp.New(context.Background(), conf)
+	require.Nil(t, err)
+	require.NotNil(t, s)
+
+	conf.Type = TypeDynamo
+	s, err = cmp.New(context.Background(), conf)
+	require.Nil(t, err)
+	require.NotNil(t, s)
+
+	conf.Type = "UNKNOWN"
+	_, err = cmp.New(context.Background(), conf)
+	require.NotNil(t, err)
+}

--- a/pkg/store/dynamo.go
+++ b/pkg/store/dynamo.go
@@ -1,0 +1,335 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	awscmp "github.com/asecurityteam/component-aws"
+	"github.com/asecurityteam/nmap-scanner/pkg/domain"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
+)
+
+const (
+	dataKey             = "data"
+	marker              = "OK"
+	defaultPartitionKey = "identity"
+	deafultTTLKey       = "ttl"
+	defaultTableName    = "ScanResults"
+)
+
+type dynamoResult struct {
+	PartitionKey string `json:"partitionKey"`
+	Data         string `json:"data"`
+}
+
+// vulnerability is a JSON domain.Vulnerability.
+type vulnerability struct {
+	Key            string
+	Title          string
+	State          string
+	IDs            []vulnerabilityID
+	RiskFactor     string
+	Scores         []vulnerabilityScore
+	Description    string
+	Dates          []vulnerabilityDate
+	CheckResults   []string
+	ExploitResults []string
+	ExtraInfo      []string
+	References     []string
+
+	Source   string
+	Port     int
+	Protocol string
+	Service  string
+}
+
+// vulnerabilityDate is a JSON domain.VulnerabilityDate.
+type vulnerabilityDate struct {
+	Type  string
+	Year  int
+	Month int
+	Day   int
+}
+
+// vulnerabilityScore is a JSON domain.VulnerabilityScore.
+type vulnerabilityScore struct {
+	Type  string
+	Value string
+}
+
+// vulnerabilityID is a JSON domain.VulnerabilityID.
+type vulnerabilityID struct {
+	Type  string
+	Value string
+}
+
+// finding is a JSON domain.Finding.
+type finding struct {
+	// Timestamp is when the finding was detected.
+	Timestamp time.Time
+	// IP is the address that was scanned.
+	IP string
+	// Hostnames are optionally included names that resolve to the scan IP.
+	Hostnames       []string
+	Vulnerabilities []vulnerability
+}
+
+func vulnerabilityFromDomain(source domain.Vulnerability) vulnerability {
+	v := vulnerability{
+		Key:            source.Key,
+		Title:          source.Title,
+		State:          source.State,
+		IDs:            make([]vulnerabilityID, 0, len(source.IDs)),
+		RiskFactor:     source.RiskFactor,
+		Scores:         make([]vulnerabilityScore, 0, len(source.Scores)),
+		Description:    source.Description,
+		Dates:          make([]vulnerabilityDate, 0, len(source.Dates)),
+		CheckResults:   source.CheckResults,
+		ExploitResults: source.ExploitResults,
+		ExtraInfo:      source.ExtraInfo,
+		References:     source.References,
+		Source:         source.Source,
+		Port:           source.Port,
+		Protocol:       source.Protocol,
+		Service:        source.Service,
+	}
+	for _, id := range source.IDs {
+		v.IDs = append(v.IDs, vulnerabilityID(id))
+	}
+	for _, score := range source.Scores {
+		v.Scores = append(v.Scores, vulnerabilityScore(score))
+	}
+	for _, date := range source.Dates {
+		v.Dates = append(v.Dates, vulnerabilityDate(date))
+	}
+
+	return v
+}
+
+func findingFromDomain(source domain.Finding) finding {
+	f := finding{
+		Timestamp:       source.Timestamp,
+		IP:              source.IP,
+		Hostnames:       source.Hostnames,
+		Vulnerabilities: make([]vulnerability, 0, len(source.Vulnerabilities)),
+	}
+	for _, v := range source.Vulnerabilities {
+		f.Vulnerabilities = append(f.Vulnerabilities, vulnerabilityFromDomain(v))
+	}
+	return f
+}
+
+func vulnerabilityToDomain(source vulnerability) domain.Vulnerability {
+	v := domain.Vulnerability{
+		Key:            source.Key,
+		Title:          source.Title,
+		State:          source.State,
+		IDs:            make([]domain.VulnerabilityID, 0, len(source.IDs)),
+		RiskFactor:     source.RiskFactor,
+		Scores:         make([]domain.VulnerabilityScore, 0, len(source.Scores)),
+		Description:    source.Description,
+		Dates:          make([]domain.VulnerabilityDate, 0, len(source.Dates)),
+		CheckResults:   source.CheckResults,
+		ExploitResults: source.ExploitResults,
+		ExtraInfo:      source.ExtraInfo,
+		References:     source.References,
+		Source:         source.Source,
+		Port:           source.Port,
+		Protocol:       source.Protocol,
+		Service:        source.Service,
+	}
+	for _, id := range source.IDs {
+		v.IDs = append(v.IDs, domain.VulnerabilityID(id))
+	}
+	for _, score := range source.Scores {
+		v.Scores = append(v.Scores, domain.VulnerabilityScore(score))
+	}
+	for _, date := range source.Dates {
+		v.Dates = append(v.Dates, domain.VulnerabilityDate(date))
+	}
+
+	return v
+}
+
+func findingToDomain(source finding) domain.Finding {
+	f := domain.Finding{
+		Timestamp:       source.Timestamp,
+		IP:              source.IP,
+		Hostnames:       source.Hostnames,
+		Vulnerabilities: make([]domain.Vulnerability, 0, len(source.Vulnerabilities)),
+	}
+	for _, v := range source.Vulnerabilities {
+		f.Vulnerabilities = append(f.Vulnerabilities, vulnerabilityToDomain(v))
+	}
+	return f
+}
+
+func toDomain(source []finding) []domain.Finding {
+	r := make([]domain.Finding, 0, len(source))
+	for _, s := range source {
+		r = append(r, findingToDomain(s))
+	}
+	return r
+}
+
+func fromDomain(source []domain.Finding) []finding {
+	r := make([]finding, 0, len(source))
+	for _, s := range source {
+		r = append(r, findingFromDomain(s))
+	}
+	return r
+}
+
+// DynamoDB implements store using AWS DynamoDB.
+type DynamoDB struct {
+	Client           dynamodbiface.DynamoDBAPI
+	TableName        string
+	PartitionKeyName string
+	TTLKeyName       string
+}
+
+// Mark the identifier as in-progress.
+func (s *DynamoDB) Mark(ctx context.Context, identifier string) error {
+	_, err := s.Client.PutItemWithContext(ctx, &dynamodb.PutItemInput{
+		TableName: aws.String(s.TableName),
+		Item: map[string]*dynamodb.AttributeValue{
+			s.PartitionKeyName: {
+				S: aws.String(identifier + "-marker"),
+			},
+			dataKey: {
+				S: aws.String(marker),
+			},
+			s.TTLKeyName: {
+				N: aws.String(fmt.Sprintf("%d", time.Now().Add(time.Hour).Unix())),
+			},
+		},
+	})
+	return err
+}
+
+// Set the value of the identifier.
+func (s *DynamoDB) Set(ctx context.Context, identifier string, findings []domain.Finding) error {
+	b, _ := json.Marshal(fromDomain(findings))
+	_, err := s.Client.PutItemWithContext(ctx, &dynamodb.PutItemInput{
+		TableName: aws.String(s.TableName),
+		Item: map[string]*dynamodb.AttributeValue{
+			s.PartitionKeyName: {
+				S: aws.String(identifier),
+			},
+			dataKey: {
+				S: aws.String(string(b)),
+			},
+			s.TTLKeyName: {
+				N: aws.String(fmt.Sprintf("%d", time.Now().Add(time.Hour).Unix())),
+			},
+		},
+	})
+	return err
+}
+
+// Load the value of the identifier.
+func (s *DynamoDB) Load(ctx context.Context, identifier string) ([]domain.Finding, error) {
+	item, err := s.Client.GetItemWithContext(ctx, &dynamodb.GetItemInput{
+		TableName: aws.String(s.TableName),
+		Key: map[string]*dynamodb.AttributeValue{
+			s.PartitionKeyName: {
+				S: aws.String(identifier),
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch result: %v", err)
+	}
+
+	var result dynamoResult
+	err = dynamodbattribute.UnmarshalMap(item.Item, &result)
+	if err == nil && len(item.Item) > 0 {
+		var f []finding
+		err = json.Unmarshal([]byte(result.Data), &f)
+		if err != nil {
+			return nil, fmt.Errorf("failed to unmarshal result: %v,", err)
+		}
+		return toDomain(f), nil
+	}
+
+	item, err = s.Client.GetItemWithContext(ctx, &dynamodb.GetItemInput{
+		TableName: aws.String(s.TableName),
+		Key: map[string]*dynamodb.AttributeValue{
+			s.PartitionKeyName: {
+				S: aws.String(identifier + "-marker"),
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch marker: %v", err)
+	}
+	err = dynamodbattribute.UnmarshalMap(item.Item, &result)
+	if err == nil && result.Data == marker {
+		return nil, domain.InProgressError{Identifier: identifier}
+	}
+	return nil, domain.NotFoundError{Identifier: identifier}
+}
+
+// DynamoConf wraps the original config to add a name.
+type DynamoConf struct {
+	*awscmp.DynamoDBConfig
+}
+
+// Name of the configuration root.
+func (*DynamoConf) Name() string {
+	return "aws"
+}
+
+// DynamoConfig contains all settings for the in-memory component.
+type DynamoConfig struct {
+	TableName    string `description:"The name of the DynamoDB table to use."`
+	PartitionKey string `description:"Name of the table partition key."`
+	TTLKey       string `description:"Name of the TTL key."`
+	AWS          *DynamoConf
+}
+
+// Name of the configuration root.
+func (*DynamoConfig) Name() string {
+	return "dynamodb"
+}
+
+// DynamoComponent implements the component interface for the in-memory option.
+type DynamoComponent struct {
+	DynamoDB *awscmp.DynamoDBComponent
+}
+
+// NewDynamoComponent constructs a default DynamoComponent.
+func NewDynamoComponent() *DynamoComponent {
+	return &DynamoComponent{
+		DynamoDB: awscmp.NewDynamoDBComponent(),
+	}
+}
+
+// Settings returns the default configuration.
+func (c *DynamoComponent) Settings() *DynamoConfig {
+	return &DynamoConfig{
+		TableName:    defaultTableName,
+		PartitionKey: defaultPartitionKey,
+		TTLKey:       deafultTTLKey,
+		AWS:          &DynamoConf{c.DynamoDB.Settings()},
+	}
+}
+
+// New constructs the component.
+func (c *DynamoComponent) New(ctx context.Context, conf *DynamoConfig) (domain.Store, error) {
+	client, err := c.DynamoDB.New(ctx, conf.AWS.DynamoDBConfig)
+	if err != nil {
+		return nil, err
+	}
+	return &DynamoDB{
+		Client:           client,
+		TableName:        conf.TableName,
+		PartitionKeyName: conf.PartitionKey,
+		TTLKeyName:       conf.TTLKey,
+	}, nil
+}

--- a/pkg/store/dynamo_test.go
+++ b/pkg/store/dynamo_test.go
@@ -1,0 +1,15 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDynamoComponent(t *testing.T) {
+	cmp := NewDynamoComponent()
+	conf := cmp.Settings()
+
+	require.Equal(t, "dynamodb", conf.Name())
+	require.Equal(t, "aws", conf.AWS.Name())
+}

--- a/pkg/store/memory.go
+++ b/pkg/store/memory.go
@@ -1,0 +1,69 @@
+package store
+
+import (
+	"context"
+	"sync"
+
+	"github.com/asecurityteam/nmap-scanner/pkg/domain"
+)
+
+// Memory is an in-memory implementation of the store. This may be used for
+// cases where only one instance of the service is running but is not compatible
+// with multi-node deployments.
+//
+// Note: This implementation does not clean up after itself and will grow
+// unbounded over time. This is not for production use.
+type Memory struct {
+	Map sync.Map
+}
+
+// Mark the identifier as in-progress.
+func (s *Memory) Mark(ctx context.Context, identifier string) error {
+	s.Map.Store(identifier+"-marker", true)
+	return nil
+}
+
+// Set the value of the identifier.
+func (s *Memory) Set(ctx context.Context, identifier string, findings []domain.Finding) error {
+	s.Map.Store(identifier, findings)
+	return nil
+}
+
+// Load the value of the identifier.
+func (s *Memory) Load(ctx context.Context, identifier string) ([]domain.Finding, error) {
+	f, ok := s.Map.Load(identifier)
+	if ok {
+		return f.([]domain.Finding), nil
+	}
+	_, ok = s.Map.Load(identifier + "-marker")
+	if ok {
+		return nil, domain.InProgressError{Identifier: identifier}
+	}
+	return nil, domain.NotFoundError{Identifier: identifier}
+}
+
+// MemoryConfig contains all settings for the in-memory component.
+type MemoryConfig struct{}
+
+// Name of the configuration root.
+func (*MemoryConfig) Name() string {
+	return "memory"
+}
+
+// MemoryComponent implements the component interface for the in-memory option.
+type MemoryComponent struct{}
+
+// NewMemoryComponent constructs a default MemoryComponent.
+func NewMemoryComponent() *MemoryComponent {
+	return &MemoryComponent{}
+}
+
+// Settings returns the default configuration.
+func (*MemoryComponent) Settings() *MemoryConfig {
+	return &MemoryConfig{}
+}
+
+// New constructs the component.
+func (*MemoryComponent) New(ctx context.Context, conf *MemoryConfig) (domain.Store, error) {
+	return &Memory{}, nil
+}

--- a/pkg/store/memory_test.go
+++ b/pkg/store/memory_test.go
@@ -1,0 +1,37 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/asecurityteam/nmap-scanner/pkg/domain"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMemory(t *testing.T) {
+	cmp := NewMemoryComponent()
+	ctx := context.Background()
+	id := "test"
+
+	s, err := cmp.New(ctx, cmp.Settings())
+	require.Nil(t, err)
+	require.NotNil(t, s)
+
+	_, err = s.Load(ctx, id)
+	require.NotNil(t, err)
+	require.IsType(t, domain.NotFoundError{}, err)
+
+	err = s.Mark(ctx, id)
+	require.Nil(t, err)
+	_, err = s.Load(ctx, id)
+	require.NotNil(t, err)
+	require.IsType(t, domain.InProgressError{}, err)
+
+	expected := []domain.Finding{{Timestamp: time.Now()}}
+	err = s.Set(ctx, id, expected)
+	require.Nil(t, err)
+	r, err := s.Load(ctx, id)
+	require.Nil(t, err)
+	require.Equal(t, expected, r)
+}


### PR DESCRIPTION
Add memory based storage for running the scanner on workstations.

Add DynamoDB storage for running in production.